### PR TITLE
Cleanup SnapshotService naming

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClient.cs
@@ -12,7 +12,7 @@ using Roslyn.Utilities;
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Remote
 {
     /// <summary>
-    /// This lets users create a session to communicate with remote host (i.e. ServiceHub)
+    /// Let's users create a session to communicate with remote host (i.e. ServiceHub)
     /// </summary>
     internal abstract class RemoteHostClient
     {

--- a/src/VisualStudio/Next/Remote/ServiceHubRemoteHostClient.JsonRpcSnapshot.cs
+++ b/src/VisualStudio/Next/Remote/ServiceHubRemoteHostClient.JsonRpcSnapshot.cs
@@ -106,6 +106,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 }
 
                 private ChecksumScope ChecksumScope => _owner.ChecksumScope;
+
                 protected override object GetTarget() => this;
 
                 public async Task RequestAssetAsync(int serviceId, byte[] checksum, string streamName)

--- a/src/VisualStudio/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
         {
             // get stream from service hub to communicate snapshot/asset related information
             // this is the back channel the system uses to move data between VS and remote host
-            var snapshotStream = await _hubClient.RequestServiceAsync(WellKnownServiceHubServices.ServiceHubSnapshotService, cancellationToken).ConfigureAwait(false);
+            var snapshotStream = await _hubClient.RequestServiceAsync(WellKnownServiceHubServices.SnapshotService, cancellationToken).ConfigureAwait(false);
 
             // get stream from service hub to communicate service specific information
             // this is what consumer actually use to communicate information

--- a/src/VisualStudio/Setup.Next/VisualStudioSetup.Next.csproj
+++ b/src/VisualStudio/Setup.Next/VisualStudioSetup.Next.csproj
@@ -121,7 +121,7 @@
     <StartArguments>/rootsuffix RoslynDev /log</StartArguments>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="serviceHubSnapshotService.servicehub.service.json">
+    <Content Include="snapshotService.servicehub.service.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>

--- a/src/VisualStudio/Setup.Next/snapshotService.servicehub.service.json
+++ b/src/VisualStudio/Setup.Next/snapshotService.servicehub.service.json
@@ -4,6 +4,6 @@
   "hostId": "RoslynCodeAnalysisService32",
   "entryPoint": {
     "assemblyPath": "Microsoft.CodeAnalysis.Remote.ServiceHub.dll",
-    "fullClassName": "Microsoft.CodeAnalysis.Remote.ServiceHubSnapshotService"
+    "fullClassName": "Microsoft.CodeAnalysis.Remote.SnapshotService"
   }
 }

--- a/src/VisualStudio/Setup.Next/source.extension.vsixmanifest
+++ b/src/VisualStudio/Setup.Next/source.extension.vsixmanifest
@@ -24,7 +24,7 @@
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="EditorFeatures.Next" Path="|EditorFeatures.Next|" />
     <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="remoteHostService.servicehub.service.json" />
-    <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="serviceHubSnapshotService.servicehub.service.json" />
+    <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="snapshotService.servicehub.service.json" />
     <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="codeAnalysisService.servicehub.service.json" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="ServicesVisualStudio.Next" Path="|ServicesVisualStudio.Next|" />
   </Assets>

--- a/src/Workspaces/Remote/ServiceHub/ServiceHub.csproj
+++ b/src/Workspaces/Remote/ServiceHub/ServiceHub.csproj
@@ -62,7 +62,7 @@
     <Compile Include="Services\RemoteHostService.cs" />
     <Compile Include="Services\ServiceHubJsonRpcServiceBase.cs" />
     <Compile Include="Services\ServiceHubServiceBase.cs" />
-    <Compile Include="Services\SnapshotService.AssetSource.cs" />
+    <Compile Include="Services\SnapshotService.JsonRpcAssetSource.cs" />
     <Compile Include="Services\SnapshotService.cs" />
     <Compile Include="Shared\Extensions.cs" />
     <Compile Include="Shared\ServerDirectStream.cs" />

--- a/src/Workspaces/Remote/ServiceHub/ServiceHub.csproj
+++ b/src/Workspaces/Remote/ServiceHub/ServiceHub.csproj
@@ -62,7 +62,8 @@
     <Compile Include="Services\RemoteHostService.cs" />
     <Compile Include="Services\ServiceHubJsonRpcServiceBase.cs" />
     <Compile Include="Services\ServiceHubServiceBase.cs" />
-    <Compile Include="Services\ServiceHubSnapshotService.cs" />
+    <Compile Include="Services\SnapshotService.AssetSource.cs" />
+    <Compile Include="Services\SnapshotService.cs" />
     <Compile Include="Shared\Extensions.cs" />
     <Compile Include="Shared\ServerDirectStream.cs" />
     <Compile Include="Shared\ClientDirectStream.cs" />

--- a/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.JsonRpcAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.JsonRpcAssetSource.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -11,34 +10,15 @@ using StreamJsonRpc;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
-    /// <summary>
-    /// Snapshot service in service hub side.
-    /// 
-    /// this service will be used to move over snapshot data from client to service hub
-    /// </summary>
-    internal class ServiceHubSnapshotService : ServiceHubJsonRpcServiceBase
+    internal partial class SnapshotService
     {
-        private readonly AssetSource _source;
-
-        public ServiceHubSnapshotService(Stream stream, IServiceProvider serviceProvider) :
-            base(stream, serviceProvider)
-        {
-            _source = new ServiceHubAssetSource(Rpc, Logger, CancellationToken);
-        }
-
-        protected override void OnDisconnected(JsonRpcDisconnectedEventArgs e)
-        {
-            _source.Done();
-        }
-
-        private class ServiceHubAssetSource : AssetSource
+        private class JsonRpcAssetSource : AssetSource
         {
             private readonly JsonRpc _rpc;
             private readonly TraceSource _logger;
             private readonly CancellationToken _assetChannelCancellationToken;
 
-            public ServiceHubAssetSource(JsonRpc rpc, TraceSource logger, CancellationToken assetChannelCancellationToken) :
-                base()
+            public JsonRpcAssetSource(JsonRpc rpc, TraceSource logger, CancellationToken assetChannelCancellationToken)
             {
                 _rpc = rpc;
                 _logger = logger;

--- a/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using StreamJsonRpc;
+
+namespace Microsoft.CodeAnalysis.Remote
+{
+    /// <summary>
+    /// Snapshot service in service hub side.
+    /// 
+    /// this service will be used to move over snapshot data from client to service hub
+    /// </summary>
+    internal partial class SnapshotService : ServiceHubJsonRpcServiceBase
+    {
+        private readonly AssetSource _source;
+
+        public SnapshotService(Stream stream, IServiceProvider serviceProvider) :
+            base(stream, serviceProvider)
+        {
+            _source = new JsonRpcAssetSource(Rpc, Logger, CancellationToken);
+        }
+
+        protected override void OnDisconnected(JsonRpcDisconnectedEventArgs e)
+        {
+            _source.Done();
+        }
+    }
+}

--- a/src/Workspaces/Remote/ServiceHub/Shared/WellKnownServiceHubServices.cs
+++ b/src/Workspaces/Remote/ServiceHub/Shared/WellKnownServiceHubServices.cs
@@ -7,8 +7,8 @@ namespace Microsoft.CodeAnalysis.Remote
         public const string RemoteHostService = "remoteHostService";
         public const string RemoteHostService_Connect = "Connect";
 
-        public const string ServiceHubSnapshotService = "serviceHubSnapshotService";
-        public const string ServiceHubSnapshotService_Done = "Done";
+        public const string SnapshotService = "snapshotService";
+        public const string SnapshotService_Done = "Done";
 
         public const string CodeAnalysisService = "codeAnalysisService";
         public const string CodeAnalysisService_CalculateDiagnosticsAsync = "CalculateDiagnosticsAsync";


### PR DESCRIPTION
Another minor cleanup (hopefully these aren't annoying @heejaechang), the ServiceHubAssetService was a bit of an unwieldy name especially since all the other services didn't have the "ServiceHub" prefix (CodeAnalysisService, RemoteHostService).
